### PR TITLE
Remove dialog from the sendEventsComponents action form

### DIFF
--- a/src/view/actions/sendEventsComponents/fields.jsx
+++ b/src/view/actions/sendEventsComponents/fields.jsx
@@ -3,12 +3,11 @@
  *
  * @format
  */
-import React from 'react';
-import {useFormContext} from 'react-hook-form';
+import React from "react";
+import { useFormContext } from "react-hook-form";
 import {
   Checkbox,
   Content,
-  Dialog,
   Divider,
   Flex,
   Heading,
@@ -16,31 +15,31 @@ import {
   Text,
   TextField,
   TextArea,
-} from '@adobe/react-spectrum';
-import WrappedTextField from '../../components/wrappedTextField';
-import WrappedCheckboxComponent from '../../components/wrappedCheckboxComponent';
-import Parameters from './getParameters';
+} from "@adobe/react-spectrum";
+import WrappedTextField from "../../components/wrappedTextField";
+import WrappedCheckboxComponent from "../../components/wrappedCheckboxComponent";
+import Parameters from "./getParameters";
 
 export default () => {
-  const {watch} = useFormContext();
-  const isTestEvent = watch('isTestEvent');
-  const {customerInformation, serverEvents} = Parameters();
+  const { watch } = useFormContext();
+  const isTestEvent = watch("isTestEvent");
+  const { customerInformation, serverEvents } = Parameters();
   const parametersURI =
-    'https://developers.facebook.com/docs/marketing-api/conversions-api/parameters';
+    "https://developers.facebook.com/docs/marketing-api/conversions-api/parameters";
   const dpoURI =
-    'https://developers.facebook.com/docs/marketing-apis/data-processing-options/';
+    "https://developers.facebook.com/docs/marketing-apis/data-processing-options/";
   const serverEventsURI =
-    'https://developers.facebook.com/docs/marketing-api/conversions-api/parameters/server-event';
+    "https://developers.facebook.com/docs/marketing-api/conversions-api/parameters/server-event";
   const customerInformationURI =
-    'https://developers.facebook.com/docs/marketing-api/conversions-api/parameters/customer-information-parameters';
+    "https://developers.facebook.com/docs/marketing-api/conversions-api/parameters/customer-information-parameters";
   const customDataURI =
-    'https://developers.facebook.com/docs/marketing-api/conversions-api/parameters/custom-data';
+    "https://developers.facebook.com/docs/marketing-api/conversions-api/parameters/custom-data";
 
   const facebookEventSetupText = `Use the data mapping below to configure a Facebook event using
     your data from Adobe Edge. These events will be sent to your Pixel via Facebook Conversions
     API. For more information about these parameters, go to `;
   const serverEventsParametersText =
-    'Send actions that occur as a Facebook Standard or Custom Event. For more detail, see the ';
+    "Send actions that occur as a Facebook Standard or Custom Event. For more detail, see the ";
   const customerInformationText = `These parameters are a set of identifiers Facebook can use
     for targeted attribution. You must provide at least one of the following keys in your
     request. For more detail, see the `;
@@ -52,128 +51,123 @@ export default () => {
     test ID here to start seeing event activity appear in the Test Events window.`;
 
   return (
-    <Dialog>
-      <Flex direction="row" gap="size-200">
-        <Flex direction="column" gap="size-65">
-          <Heading> Facebook Event Setup </Heading>
-          <Divider size="S" />
-          <Content>
-            <Text>{facebookEventSetupText}</Text>
+    <Flex direction="row" gap="size-200">
+      <Flex direction="column" gap="size-65">
+        <Heading> Facebook Event Setup </Heading>
+        <Divider size="S" />
+        <Content>
+          <Text>{facebookEventSetupText}</Text>
+          <Link>
+            <a href={parametersURI} target="_blank" rel="noreferrer">
+              Facebook for Developers.
+            </a>
+          </Link>
+        </Content>
+
+        <Heading marginTop="1em"> Server Event Parameters</Heading>
+        <Divider size="S" />
+        <Content>
+          <Content marginBottom="1em">
+            <Text>{serverEventsParametersText}</Text>
             <Link>
-              <a href={parametersURI} target="_blank" rel="noreferrer">
-                Facebook for Developers.
+              <a href={serverEventsURI} target="_blank" rel="noreferrer">
+                documentation.
               </a>
             </Link>
           </Content>
-
-          <Heading marginTop="1em"> Server Event Parameters</Heading>
-          <Divider size="S" />
+          {serverEvents.map(([name, label], index) => {
+            return (
+              <WrappedTextField
+                key={index}
+                name={name}
+                component={TextField}
+                width="size-4600"
+                label={label}
+                supportDataElement
+              />
+            );
+          })}
+          <WrappedCheckboxComponent component={Checkbox} name="lduEnabled">
+            <Text>Enable Limited Data Use</Text>
+          </WrappedCheckboxComponent>
           <Content>
-            <Content marginBottom="1em">
-              <Text>{serverEventsParametersText}</Text>
+            <Text>
+              Learn more about{" "}
               <Link>
-                <a href={serverEventsURI} target="_blank" rel="noreferrer">
-                  documentation.
+                <a href={dpoURI} target="_blank" rel="noreferrer">
+                  Limited Data Use and Data Processing Options
                 </a>
               </Link>
-            </Content>
-            {serverEvents.map(([name, label], index) => {
-              return (
-                <WrappedTextField
-                  key={index}
-                  name={name}
-                  component={TextField}
-                  width="size-4600"
-                  label={label}
-                  supportDataElement
-                />
-              );
-            })}
-            <WrappedCheckboxComponent component={Checkbox} name="lduEnabled">
-              <Text>Enable Limited Data Use</Text>
-            </WrappedCheckboxComponent>
-            <Content>
-              <Text>
-                Learn more about{' '}
-                <Link>
-                  <a href={dpoURI} target="_blank" rel="noreferrer">
-                    Limited Data Use and Data Processing Options
-                  </a>
-                </Link>
-              </Text>
-            </Content>
+            </Text>
           </Content>
+        </Content>
 
-          <Heading marginTop="1em"> Customer Information Parameters </Heading>
-          <Divider size="S" />
-          <Content>
-            <Content marginBottom="1em">
-              <Text>{customerInformationText}</Text>
-              <Link>
-                <a
-                  href={customerInformationURI}
-                  target="_blank"
-                  rel="noreferrer">
-                  documentation.
-                </a>
-              </Link>
-            </Content>
-            {customerInformation.map(([name, label], index) => {
-              return (
-                <WrappedTextField
-                  key={index}
-                  name={name}
-                  component={TextField}
-                  width="size-4600"
-                  label={label}
-                  supportDataElement
-                />
-              );
-            })}
+        <Heading marginTop="1em"> Customer Information Parameters </Heading>
+        <Divider size="S" />
+        <Content>
+          <Content marginBottom="1em">
+            <Text>{customerInformationText}</Text>
+            <Link>
+              <a href={customerInformationURI} target="_blank" rel="noreferrer">
+                documentation.
+              </a>
+            </Link>
           </Content>
+          {customerInformation.map(([name, label], index) => {
+            return (
+              <WrappedTextField
+                key={index}
+                name={name}
+                component={TextField}
+                width="size-4600"
+                label={label}
+                supportDataElement
+              />
+            );
+          })}
+        </Content>
 
-          <Heading marginTop="1em"> Custom Data </Heading>
-          <Divider size="S" />
-          <Content>
-            <Content marginBottom="1em">
-              <Text>{customDataText}</Text>
-              <Link marginBottom="1em">
-                <a href={customDataURI} target="_blank" rel="noreferrer">
-                  documentation.
-                </a>
-              </Link>
-            </Content>
-            <WrappedTextField
-              name="customData"
-              component={TextArea}
-              width="size-4600"
-              label="Custom Data"
-              placeholder='{"currency": "usd", "value": 123.45}'
-              supportDataElement
-            />
+        <Heading marginTop="1em"> Custom Data </Heading>
+        <Divider size="S" />
+        <Content>
+          <Content marginBottom="1em">
+            <Text>{customDataText}</Text>
+            <Link marginBottom="1em">
+              <a href={customDataURI} target="_blank" rel="noreferrer">
+                documentation.
+              </a>
+            </Link>
           </Content>
+          <WrappedTextField
+            name="customData"
+            component={TextArea}
+            width="size-4600"
+            label="Custom Data"
+            placeholder='{"currency": "usd", "value": 123.45}'
+            supportDataElement
+          />
+        </Content>
 
-          <Heading marginTop="1em"> Test Event </Heading>
-          <Divider size="S" />
-          <Content>
-            <Content marginBottom="1em">
-              <Text>{testEventText}</Text>
-            </Content>
-            <WrappedCheckboxComponent component={Checkbox} name="isTestEvent">
-              Send as Test Event
-            </WrappedCheckboxComponent>
-            <WrappedTextField
-              name="testEventCode"
-              component={TextField}
-              width="size-4600"
-              label="Test Event Code"
-              isRequired
-              isDisabled={!isTestEvent}
-              necessityIndicator="label"
-            />
+        <Heading marginTop="1em"> Test Event </Heading>
+        <Divider size="S" />
+        <Content>
+          <Content marginBottom="1em">
+            <Text>{testEventText}</Text>
           </Content>
-        </Flex>
+          <WrappedCheckboxComponent component={Checkbox} name="isTestEvent">
+            Send as Test Event
+          </WrappedCheckboxComponent>
+          <WrappedTextField
+            name="testEventCode"
+            component={TextField}
+            width="size-4600"
+            label="Test Event Code"
+            isRequired
+            isDisabled={!isTestEvent}
+            necessityIndicator="label"
+          />
+        </Content>
       </Flex>
-    </Dialog>
+    </Flex>
   );
 };


### PR DESCRIPTION
So I don't think the react-spectrum Dialog component is intended to be used this way. While researching why focus is being stolen inside of the product previously know as Launch. I found that the Dialog component in this extension is continually trying to keep focus on its children. Which probably makes sense in a situation where you are using it as a modal. 

So just removing this fixes the focus problem. But it also makes the extension view have a dynamic with. If that is a problem then that will need to be addressed as well. 

This fixes the focus problems.